### PR TITLE
初始化ApplicationHelper

### DIFF
--- a/app/src/main/java/com/lzw/applicationhelper/ApplicationHelper.java
+++ b/app/src/main/java/com/lzw/applicationhelper/ApplicationHelper.java
@@ -19,13 +19,13 @@ public class ApplicationHelper implements IInitMethods{
     private static ApplicationHelper mInstance;
     private static InitWrapperImpl sInstance;
 
-    private ApplicationHelper(){
-        if(mInstance == null){
-            mInstance = new ApplicationHelper();
-        }
+    private ApplicationHelper() {
     }
 
-    public static ApplicationHelper init(Context context){
+    public static ApplicationHelper init(Context context) {
+        if (mInstance == null) {
+            mInstance = new ApplicationHelper();
+        }
         mContext = context;
         sInstance = InitWrapperImpl.getInstance();
         sInstance.init(mContext);


### PR DESCRIPTION
如果不在init的时候初始化ApplicationHelper，那所有的mInstance都会为null，无法继续执行下面的代码。